### PR TITLE
Docs: update versioning guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,6 @@ Conventional Commit......................................................Passed
 
 Versioning generally follows [Semantic Versioning](https://semver.org/).
 
-In addition to the strict version tag, we also maintain a "latest" tag for each
-major version, e.g. `v1` always points to the latest `v1.x.x` tag.
-
 ## License
 
 [Apache 2.0](LICENSE)


### PR DESCRIPTION
We're not going to maintain the "latest" style mutable tags any longer. Closes #10.