### PR TITLE
feat: allow underscore in scopes

### DIFF
--- a/conventional-pre-commit.sh
+++ b/conventional-pre-commit.sh
@@ -21,7 +21,7 @@ msg_file="$1"
 # join types with | to form regex ORs
 r_types="($(IFS='|'; echo "${types[*]}"))"
 # optional (scope)
-r_scope="(\([[:alnum:] \/-]+\))?"
+r_scope="(\([[:alnum:] \/-_]+\))?"
 # optional breaking change indicator and colon delimiter
 r_delim='!?:'
 # subject line, body, footer

--- a/tests.sh
+++ b/tests.sh
@@ -113,4 +113,18 @@ echo "$pass" | grep -Eq "\[main \(root-commit\) [[:alnum:]]{7}\] test: conventio
 
 echo "$result"
 
+echo "test underscore in scope"
+
+setup
+
+pass="$(git commit -m 'test(some_component): conventional-pre-commit')"
+
+teardown
+
+echo "$pass" | grep -Eq "\[main \(root-commit\) [[:alnum:]]{7}\] test\(some_component\): conventional-pre-commit"
+
+(( result += "$?" ))
+
+echo "$result"
+
 exit "$result"


### PR DESCRIPTION
We have a lot of sub-packages with underscores in their names in our repos. The current regex forbids
```
feat(some_package): added some feature
```
as the commit message.

I just added `_` to the allowed characters in the scope regex to allow it.