### PR TITLE
Fix: TestPyPI skip existing, verbose logging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TEST_API_TOKEN }}
+          print_hash: true
+          skip_existing: true
+          verbose: true
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1.5
@@ -36,3 +39,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+          print_hash: true


### PR DESCRIPTION
Trying to figure out why the [push is failing](https://github.com/compilerla/conventional-pre-commit/runs/7681472201?check_suite_focus=true)