### PR TITLE
Fix: override TestPyPI repo url

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TEST_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
           print_hash: true
           skip_existing: true
           verbose: true


### PR DESCRIPTION
One final (hopefully) fix.