### PR TITLE
Add commit encoding setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Conventional Commit......................................................Passed
 args: [--encoding=<encoding>]
 ```
 
-or 
+or
 
 ```yaml
 args: [--encoding=<encoding>, feat, ...(other custom types)]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ repos:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [] # optional: list of Conventional Commits types to allow e.g. [feat, fix, ci, chore, test]
+                 # if you want to set encoding, use --encoding=<encoding>, before types
 ```
 
 Install the `pre-commit` script:
@@ -79,6 +80,22 @@ Conventional Commit......................................................Passed
 - duration: 0.05s
 ```
 
+### Configure encoding
+
+**For Windows user**, if you want to use `conventional-pre-commit` with non-ascii characters, you can set encoding with `--encoding=<encoding>`.
+
+```yaml
+args: [--encoding=<encoding>]
+```
+
+or 
+
+```yaml
+args: [--encoding=<encoding>, feat, ...(other custom types)]
+```
+
+**The encoding argument must be in front of types.**
+
 ## Install with pip
 
 `conventional-pre-commit` can also be installed and used from the command line:
@@ -90,15 +107,17 @@ pip install conventional-pre-commit
 Then run the command line script:
 
 ```shell
-conventional-pre-commit [types] input
+conventional-pre-commit [--encoding] [types] input
 ```
 
-Where `[types]` is an optional list of Conventional Commit types to allow (e.g. `feat fix chore`)
+- `--encoding` is an optional encoding to use (e.g. `--encoding=utf-8`)
 
-And `input` is a file containing the commit message to check:
+- `[types]` is an optional list of Conventional Commit types to allow (e.g. `feat fix chore`)
+
+- `input` is a file containing the commit message to check:
 
 ```shell
-conventional-pre-commit feat fix chore ci test .git/COMMIT_MSG
+conventional-pre-commit --encoding=utf-8 feat fix chore ci test .git/COMMIT_MSG
 ```
 
 Or from a Python program:

--- a/conventional_pre_commit/hook.py
+++ b/conventional_pre_commit/hook.py
@@ -41,7 +41,7 @@ def main(argv=[]):
 {Colors.YELLOW}It looks like we couldn't decode your commit message using the encoding you or your system specified.
 You can specify an encoding using the --encoding flag.{Colors.RESTORE}
 
-For example, if your commit message is encoded in {Colors.YELLOW}UTF-8{Colors.RESTORE}, 
+For example, if your commit message is encoded in {Colors.YELLOW}UTF-8{Colors.RESTORE},
 you can add this to your .pre-commit-config.yaml file:
 
   - repo: https://github.com/compilerla/conventional-pre-commit

--- a/conventional_pre_commit/hook.py
+++ b/conventional_pre_commit/hook.py
@@ -18,6 +18,7 @@ def main(argv=[]):
     parser = argparse.ArgumentParser(
         prog="conventional-pre-commit", description="Check a git commit message for Conventional Commits formatting."
     )
+    parser.add_argument("--encoding", type=str, default=None, help="Optional encoding to use when reading the commit message")
     parser.add_argument("types", type=str, nargs="*", default=format.DEFAULT_TYPES, help="Optional list of types to support")
     parser.add_argument("input", type=str, help="A file containing a git commit message")
 
@@ -29,8 +30,29 @@ def main(argv=[]):
     except SystemExit:
         return RESULT_FAIL
 
-    with open(args.input) as f:
-        message = f.read()
+    try:
+        with open(args.input, encoding=args.encoding) as f:
+            message = f.read()
+    except UnicodeDecodeError:
+        print(
+            f"""
+{Colors.LRED}[Bad Commit message encoding] {Colors.RESTORE}
+
+{Colors.YELLOW}It looks like we couldn't decode your commit message using the encoding you or your system specified.
+You can specify an encoding using the --encoding flag.{Colors.RESTORE}
+
+For example, if your commit message is encoded in {Colors.YELLOW}UTF-8{Colors.RESTORE}, 
+you can add this to your .pre-commit-config.yaml file:
+
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: xxx
+    hooks:
+      - id: conventional-pre-commit
+        stages: [ commit-msg ]
+        args: [ {Colors.YELLOW}--encoding=utf-8, {Colors.RESTORE}custom-types, ... ]
+        """
+        )
+        return RESULT_FAIL
 
     if format.is_conventional(message, args.types):
         return RESULT_SUCCESS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,3 +22,13 @@ def conventional_commit_path():
 @pytest.fixture
 def custom_commit_path():
     return get_message_path("custom_commit")
+
+
+@pytest.fixture
+def conventional_utf8_commit_path():
+    return get_message_path("conventional_commit_utf-8")
+
+
+@pytest.fixture
+def conventional_gbk_commit_path():
+    return get_message_path("conventional_commit_gbk")

--- a/tests/messages/conventional_commit_gbk
+++ b/tests/messages/conventional_commit_gbk
@@ -1,0 +1,1 @@
+feat: utf-8 test ²âÊÔ

--- a/tests/messages/conventional_commit_utf-8
+++ b/tests/messages/conventional_commit_utf-8
@@ -1,0 +1,1 @@
+feat: utf-8 test 测试

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -105,4 +105,3 @@ def test_main_fail__conventional_gbk(conventional_gbk_commit_path):
     result = main(["--encoding=utf-8", conventional_gbk_commit_path])
 
     assert result == RESULT_FAIL
-

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -80,3 +80,29 @@ def test_subprocess_success__custom_conventional(cmd, conventional_commit_path):
     result = subprocess.call((cmd, "custom", conventional_commit_path))
 
     assert result == RESULT_SUCCESS
+
+
+def test_main_success__conventional_utf8(conventional_utf8_commit_path):
+    result = main(["--encoding=utf-8", conventional_utf8_commit_path])
+
+    assert result == RESULT_SUCCESS
+
+
+@pytest.mark.skip(reason="read utf-8 file with gbk encoding will cause mojibake instead of raising UnicodeDecodeError")
+def test_main_fail__conventional_utf8(conventional_utf8_commit_path):
+    result = main(["--encoding=gbk", conventional_utf8_commit_path])
+
+    assert result == RESULT_FAIL
+
+
+def test_main_success__conventional_gbk(conventional_gbk_commit_path):
+    result = main(["--encoding=gbk", conventional_gbk_commit_path])
+
+    assert result == RESULT_SUCCESS
+
+
+def test_main_fail__conventional_gbk(conventional_gbk_commit_path):
+    result = main(["--encoding=utf-8", conventional_gbk_commit_path])
+
+    assert result == RESULT_FAIL
+


### PR DESCRIPTION
## Problem

It's a long story. For those Chinese users developing with Windows system, the system default encoding is gbk, but the applications use uft-8 most frequently. 

So when we commit with utf-8 message, the `conventional-pre-commit` will read text in gbk encoding, and raise `UnicodeDecodeError`. 

```python
with open(args.input) as f:
    message = f.read()
```

![image](https://user-images.githubusercontent.com/25633151/230755693-65eb33c8-dbdc-4745-966a-33adb143a395.png)

## Solution

Add an `--encoding` argument to specify the encoding. See `Readme.md` for more details.

