### PR TITLE
Added support for non optional scope

### DIFF
--- a/conventional_pre_commit/format.py
+++ b/conventional_pre_commit/format.py
@@ -21,9 +21,12 @@ def r_types(types):
     return "|".join(types)
 
 
-def r_scope():
+def r_scope(optional=True):
     """Regex str for an optional (scope)."""
-    return r"(\([\w \/:-]+\))?"
+    if optional:
+        return r"(\([\w \/:-]+\))?"
+    else:
+        return r"(\([\w \/:-]+\))"
 
 
 def r_delim():
@@ -43,7 +46,7 @@ def conventional_types(types=[]):
     return types
 
 
-def is_conventional(input, types=DEFAULT_TYPES):
+def is_conventional(input, types=DEFAULT_TYPES, optional_scope=True):
     """
     Returns True if input matches Conventional Commits formatting
     https://www.conventionalcommits.org
@@ -51,7 +54,7 @@ def is_conventional(input, types=DEFAULT_TYPES):
     Optionally provide a list of additional custom types.
     """
     types = conventional_types(types)
-    pattern = f"^({r_types(types)}){r_scope()}{r_delim()}{r_subject()}$"
+    pattern = f"^({r_types(types)}){r_scope(optional_scope)}{r_delim()}{r_subject()}$"
     regex = re.compile(pattern, re.DOTALL)
 
     return bool(regex.match(input))

--- a/conventional_pre_commit/hook.py
+++ b/conventional_pre_commit/hook.py
@@ -20,6 +20,9 @@ def main(argv=[]):
     )
     parser.add_argument("types", type=str, nargs="*", default=format.DEFAULT_TYPES, help="Optional list of types to support")
     parser.add_argument("input", type=str, help="A file containing a git commit message")
+    parser.add_argument(
+        "--force-scope", action="store_false", default=True, dest="optional_scope", help="Force commit to have scope defined."
+    )
 
     if len(argv) < 1:
         argv = sys.argv[1:]
@@ -44,7 +47,7 @@ See {Colors.LBLUE}https://git-scm.com/docs/git-commit/#_discussion{Colors.RESTOR
         )
         return RESULT_FAIL
 
-    if format.is_conventional(message, args.types):
+    if format.is_conventional(message, args.types, args.optional_scope):
         return RESULT_SUCCESS
     else:
         print(
@@ -66,7 +69,7 @@ See {Colors.LBLUE}https://git-scm.com/docs/git-commit/#_discussion{Colors.RESTOR
 
             fix: remove infinite loop
 
-        {Colors.YELLOW}Optionally, include a scope in parentheses after the type for more context:{Colors.RESTORE}
+        {Colors.YELLOW}Example commit with scope in parentheses after the type for more context:{Colors.RESTORE}
 
             fix(account): remove infinite loop"""
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conventional_pre_commit"
-version = "2.2.0"
+version = "2.3.0"
 description = "A pre-commit hook that checks commit messages for Conventional Commits formatting."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,11 @@ def conventional_commit_path():
 
 
 @pytest.fixture
+def conventional_commit_with_scope_path():
+    return get_message_path("conventional_commit_with_scope")
+
+
+@pytest.fixture
 def custom_commit_path():
     return get_message_path("custom_commit")
 

--- a/tests/messages/conventional_commit_with_scope
+++ b/tests/messages/conventional_commit_with_scope
@@ -1,0 +1,1 @@
+feat(scope): message

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -4,7 +4,6 @@ import pytest
 
 from conventional_pre_commit import format
 
-
 CUSTOM_TYPES = ["one", "two"]
 
 
@@ -21,6 +20,14 @@ def test_r_scope__optional():
     regex = re.compile(result)
 
     assert regex.match("")
+
+
+def test_r_scope__not_optional():
+    result = format.r_scope(optional=False)
+    regex = re.compile(result)
+
+    # Assert not optional anymore
+    assert not regex.match("")
 
 
 def test_r_scope__parenthesis_required():
@@ -185,6 +192,18 @@ def test_is_conventional__scope_space():
     input = "feat(scope) : message"
 
     assert not format.is_conventional(input)
+
+
+def test_is_conventional__scope_not_optional():
+    input = "feat: message"
+
+    assert not format.is_conventional(input, optional_scope=False)
+
+
+def test_is_conventional__scope_not_optional_empty_parenthesis():
+    input = "feat(): message"
+
+    assert not format.is_conventional(input, optional_scope=False)
 
 
 def test_is_conventional__missing_delimiter():

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -92,3 +92,15 @@ def test_main_fail__conventional_gbk(conventional_gbk_commit_path):
     result = main([conventional_gbk_commit_path])
 
     assert result == RESULT_FAIL
+
+
+def test_main_fail__conventional_with_scope(cmd, conventional_commit_path):
+    result = subprocess.call((cmd, "--force-scope", conventional_commit_path))
+
+    assert result == RESULT_FAIL
+
+
+def test_main_success__conventional_with_scope(cmd, conventional_commit_with_scope_path):
+    result = subprocess.call((cmd, "--force-scope", conventional_commit_with_scope_path))
+
+    assert result == RESULT_SUCCESS


### PR DESCRIPTION
By using the argument `--force-scope` the presense of scope in the commit message is enforced, meaning that the commit should always have a scope.