### PR TITLE
feat: introduce "strict" mode

### DIFF
--- a/conventional_pre_commit/format.py
+++ b/conventional_pre_commit/format.py
@@ -14,6 +14,11 @@ DEFAULT_TYPES = [
     "style",
     "test",
 ]
+AUTOSQUASH_PREFIXES = [
+    "amend",
+    "fixup",
+    "squash",
+]
 
 
 def r_types(types):
@@ -39,6 +44,11 @@ def r_subject():
     return r" .+"
 
 
+def r_autosquash_prefixes():
+    """Regex str for autosquash prefixes."""
+    return "|".join(AUTOSQUASH_PREFIXES)
+
+
 def conventional_types(types=[]):
     """Return a list of Conventional Commits types merged with the given types."""
     if set(types) & set(CONVENTIONAL_TYPES) == set():
@@ -55,6 +65,20 @@ def is_conventional(input, types=DEFAULT_TYPES, optional_scope=True):
     """
     types = conventional_types(types)
     pattern = f"^({r_types(types)}){r_scope(optional_scope)}{r_delim()}{r_subject()}$"
+    regex = re.compile(pattern, re.DOTALL)
+
+    return bool(regex.match(input))
+
+
+def has_autosquash_prefix(input):
+    """
+    Returns True if input starts with one of the autosquash prefixes used in git.
+    See the documentation, please https://git-scm.com/docs/git-rebase.
+
+    It doesn't check whether the rest of the input matches Conventional Commits
+    formatting.
+    """
+    pattern = f"^(({r_autosquash_prefixes()})! ).*$"
     regex = re.compile(pattern, re.DOTALL)
 
     return bool(regex.match(input))

--- a/conventional_pre_commit/hook.py
+++ b/conventional_pre_commit/hook.py
@@ -23,6 +23,9 @@ def main(argv=[]):
     parser.add_argument(
         "--force-scope", action="store_false", default=True, dest="optional_scope", help="Force commit to have scope defined."
     )
+    parser.add_argument(
+        "--strict", action="store_true", help="Force commit to strictly follow Conventional Commits formatting."
+    )
 
     if len(argv) < 1:
         argv = sys.argv[1:]
@@ -46,6 +49,10 @@ See {Colors.LBLUE}https://git-scm.com/docs/git-commit/#_discussion{Colors.RESTOR
         """
         )
         return RESULT_FAIL
+
+    if not args.strict:
+        if format.has_autosquash_prefix(message):
+            return RESULT_SUCCESS
 
     if format.is_conventional(message, args.types, args.optional_scope):
         return RESULT_SUCCESS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conventional_pre_commit"
-version = "2.3.0"
+version = "2.4.0"
 description = "A pre-commit hook that checks commit messages for Conventional Commits formatting."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,3 +37,8 @@ def conventional_utf8_commit_path():
 @pytest.fixture
 def conventional_gbk_commit_path():
     return get_message_path("conventional_commit_gbk")
+
+
+@pytest.fixture
+def fixup_commit_path():
+    return get_message_path("fixup_commit")

--- a/tests/messages/fixup_commit
+++ b/tests/messages/fixup_commit
@@ -1,0 +1,1 @@
+fixup! feature: implement something cool

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -220,15 +220,18 @@ def test_is_conventional__missing_delimiter():
     assert not format.is_conventional(input)
 
 
-@pytest.mark.parametrize('input,has_prefix', [
-    ('amend! ', True),
-    ('fixup! ', True),
-    ('squash! ', True),
-    ('squash! whatever .. $12 #', True),
-    ('squash!', False),
-    (' squash! ', False),
-    ('squash!:', False),
-    ('feat(foo):', False),
-])
+@pytest.mark.parametrize(
+    "input,has_prefix",
+    [
+        ("amend! ", True),
+        ("fixup! ", True),
+        ("squash! ", True),
+        ("squash! whatever .. $12 #", True),
+        ("squash!", False),
+        (" squash! ", False),
+        ("squash!:", False),
+        ("feat(foo):", False),
+    ],
+)
 def test_has_autosquash_prefix(input, has_prefix):
     assert format.has_autosquash_prefix(input) == has_prefix

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -102,6 +102,14 @@ def test_r_subject__special_chars():
     assert regex.match(" some thing")
 
 
+def test_r_autosquash_prefixes():
+    result = format.r_autosquash_prefixes()
+    regex = re.compile(result)
+
+    for prefix in format.AUTOSQUASH_PREFIXES:
+        assert regex.match(prefix)
+
+
 def test_conventional_types__default():
     result = format.conventional_types()
 
@@ -210,3 +218,17 @@ def test_is_conventional__missing_delimiter():
     input = "feat message"
 
     assert not format.is_conventional(input)
+
+
+@pytest.mark.parametrize('input,has_prefix', [
+    ('amend! ', True),
+    ('fixup! ', True),
+    ('squash! ', True),
+    ('squash! whatever .. $12 #', True),
+    ('squash!', False),
+    (' squash! ', False),
+    ('squash!:', False),
+    ('feat(foo):', False),
+])
+def test_has_autosquash_prefix(input, has_prefix):
+    assert format.has_autosquash_prefix(input) == has_prefix

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -104,3 +104,15 @@ def test_main_success__conventional_with_scope(cmd, conventional_commit_with_sco
     result = subprocess.call((cmd, "--force-scope", conventional_commit_with_scope_path))
 
     assert result == RESULT_SUCCESS
+
+
+def test_main_success__fixup_commit(cmd, fixup_commit_path):
+    result = subprocess.call((cmd, fixup_commit_path))
+
+    assert result == RESULT_SUCCESS
+
+
+def test_main_success__fail_commit(cmd, fixup_commit_path):
+    result = subprocess.call((cmd, "--strict", fixup_commit_path))
+
+    assert result == RESULT_FAIL


### PR DESCRIPTION
Passing "--strict" argument forces the hook to strictly validate a commit message against Conventional Commits formatting. This mode is switched off by default. It allows using fixup-like commits (starts with
 "fixup!", "amend!", and "squish!").

The motivation for adding this feature is that many people are using "git commit --fixup" workflow during the code review process. Commits with this prefix shouldn't be rejected because they can be sent to the CI before being squashed.

Issue #60