### PR TITLE
fix: align checked message content with what git actually uses eventually for its commits

### DIFF
--- a/conventional_pre_commit/format.py
+++ b/conventional_pre_commit/format.py
@@ -1,4 +1,5 @@
 import re
+from typing import Iterator
 
 CONVENTIONAL_TYPES = ["feat", "fix"]
 DEFAULT_TYPES = [
@@ -82,3 +83,26 @@ def has_autosquash_prefix(input):
     regex = re.compile(pattern, re.DOTALL)
 
     return bool(regex.match(input))
+
+
+def remove_by_git_ignored_lines(input: str) -> str:
+    """
+    After finishing a commit message, git ignores certain parts
+    and adds only the rest to the actual message stored.
+    In order to prevent failed detection of valid commit messages,
+    these postprocessing steps also need to get applied here
+    before checking for valid Conventional Commits formatting.
+    """
+
+    def get_git_postprocessed_input(_input: str) -> Iterator[str]:
+        first_non_empty_line_found = False
+        for msg_line in _input.split("\n"):
+            if not first_non_empty_line_found and not msg_line.strip():
+                continue
+            elif msg_line.strip().startswith("#"):
+                continue
+            else:
+                first_non_empty_line_found = True
+                yield msg_line
+
+    return "\n".join(get_git_postprocessed_input(input))

--- a/conventional_pre_commit/hook.py
+++ b/conventional_pre_commit/hook.py
@@ -50,6 +50,7 @@ See {Colors.LBLUE}https://git-scm.com/docs/git-commit/#_discussion{Colors.RESTOR
         )
         return RESULT_FAIL
 
+    message = format.remove_by_git_ignored_lines(message)
     if not args.strict:
         if format.has_autosquash_prefix(message):
             return RESULT_SUCCESS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conventional_pre_commit"
-version = "2.4.0"
+version = "2.4.1"
 description = "A pre-commit hook that checks commit messages for Conventional Commits formatting."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,3 +42,8 @@ def conventional_gbk_commit_path():
 @pytest.fixture
 def fixup_commit_path():
     return get_message_path("fixup_commit")
+
+
+@pytest.fixture
+def interactive_rebase_commit_path():
+    return get_message_path("interactive_rebase_commit")

--- a/tests/messages/interactive_rebase_commit
+++ b/tests/messages/interactive_rebase_commit
@@ -1,0 +1,8 @@
+# This is a combination of 2 commits.
+# This is the 1st commit message:
+
+feat: my cool new feature
+
+# The commit message #2 will be skipped:
+
+# fix: oops, forgot sth...

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -116,3 +116,9 @@ def test_main_success__fail_commit(cmd, fixup_commit_path):
     result = subprocess.call((cmd, "--strict", fixup_commit_path))
 
     assert result == RESULT_FAIL
+
+
+def test_main_success__interactive_rebase_commit(cmd, interactive_rebase_commit_path):
+    result = subprocess.call((cmd, interactive_rebase_commit_path))
+
+    assert result == RESULT_SUCCESS


### PR DESCRIPTION
Thanks for your ConvCo check code!
I was integrating it and realizing during an interactive rebase on some local commits of mine, that it does not go very well with "merged" commit messages during the rebase-steps.

I added a small test-case, which should illustrate the problem. 