### PR TITLE
feat: Validate multi-line messages

### DIFF
--- a/conventional_pre_commit/hook.py
+++ b/conventional_pre_commit/hook.py
@@ -54,7 +54,7 @@ See {Colors.LBLUE}https://git-scm.com/docs/git-commit/#_discussion{Colors.RESTOR
         if format.has_autosquash_prefix(message):
             return RESULT_SUCCESS
 
-    if format.is_conventional(message, args.types, args.optional_scope):
+    if format.is_conventional(message, args.types, args.optional_scope, args.strict):
         return RESULT_SUCCESS
     else:
         print(
@@ -64,7 +64,7 @@ See {Colors.LBLUE}https://git-scm.com/docs/git-commit/#_discussion{Colors.RESTOR
         {Colors.LBLUE}https://www.conventionalcommits.org/{Colors.YELLOW}
 
         Conventional Commits start with one of the below types, followed by a colon,
-        followed by the commit message:{Colors.RESTORE}
+        followed by the commit subject and an optional body seperated by a blank line:{Colors.RESTORE}
 
             {" ".join(format.conventional_types(args.types))}
 
@@ -78,7 +78,14 @@ See {Colors.LBLUE}https://git-scm.com/docs/git-commit/#_discussion{Colors.RESTOR
 
         {Colors.YELLOW}Example commit with scope in parentheses after the type for more context:{Colors.RESTORE}
 
-            fix(account): remove infinite loop"""
+            fix(account): remove infinite loop
+
+        {Colors.YELLOW}Example commit with a body
+
+            fix: remove infinite loop
+
+            Additional information on the issue caused by the infinite loop
+            """
         )
         return RESULT_FAIL
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,3 +42,13 @@ def conventional_gbk_commit_path():
 @pytest.fixture
 def fixup_commit_path():
     return get_message_path("fixup_commit")
+
+
+@pytest.fixture
+def conventional_commit_bad_multi_line_path():
+    return get_message_path("conventional_commit_bad_multi_line")
+
+
+@pytest.fixture
+def conventional_commit_multi_line_path():
+    return get_message_path("conventional_commit_multi_line")

--- a/tests/messages/conventional_commit_bad_multi_line
+++ b/tests/messages/conventional_commit_bad_multi_line
@@ -1,0 +1,2 @@
+fix: message
+no blank line

--- a/tests/messages/conventional_commit_multi_line
+++ b/tests/messages/conventional_commit_multi_line
@@ -1,0 +1,3 @@
+fix: message
+
+A blank line is there

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -162,13 +162,64 @@ def test_is_conventional__with_scope():
     assert format.is_conventional(input)
 
 
-def test_is_conventional__body_multiline():
+def test_is_conventional__body_multiline_not_strict():
     input = """feat(scope): message
 
     more message
     """
 
-    assert format.is_conventional(input)
+    assert format.is_conventional(input, is_strict=False)
+
+
+def test_is_conventional__body_multiline_no_body_not_strict():
+    input = """feat(scope): message
+
+    """
+    assert format.is_conventional(input, is_strict=False)
+
+
+def test_is_conventional__body_multiline_body_bad_type_strict():
+    input = """wrong: message
+
+    more_message
+    """
+
+    assert not format.is_conventional(input, is_strict=True)
+
+
+def test_is_conventional__bad_body_multiline_not_strict():
+    input = """feat(scope): message
+    more message
+    """
+
+    assert format.is_conventional(input, is_strict=False)
+
+
+def test_is_conventional__bad_body_multiline_strict():
+    input = """feat(scope): message
+    more message
+    """
+
+    assert not format.is_conventional(input, is_strict=True)
+
+
+def test_is_conventional__body_multiline_strict():
+    input = """feat(scope): message
+
+    more message
+    """
+
+    assert format.is_conventional(input, is_strict=True)
+
+
+def test_is_conventional__bad_body_multiline_paragraphs_strict():
+    input = """feat(scope): message
+    more message
+
+    more body message
+    """
+
+    assert not format.is_conventional(input, is_strict=True)
 
 
 @pytest.mark.parametrize("char", ['"', "'", "`", "#", "&"])

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -116,3 +116,21 @@ def test_main_success__fail_commit(cmd, fixup_commit_path):
     result = subprocess.call((cmd, "--strict", fixup_commit_path))
 
     assert result == RESULT_FAIL
+
+
+def test_main_success__conventional_commit_multi_line(cmd, conventional_commit_multi_line_path):
+    result = subprocess.call((cmd, conventional_commit_multi_line_path))
+
+    assert result == RESULT_SUCCESS
+
+
+def test_main_success__conventional_commit_bad_multi_line(cmd, conventional_commit_bad_multi_line_path):
+    result = subprocess.call((cmd, conventional_commit_bad_multi_line_path))
+
+    assert result == RESULT_SUCCESS
+
+
+def test_main_success__conventional_commit_bad_multi_line_strict(cmd, conventional_commit_bad_multi_line_path):
+    result = subprocess.call((cmd, "--strict", conventional_commit_bad_multi_line_path))
+
+    assert result == RESULT_FAIL


### PR DESCRIPTION
The documented conventional commit specification states that on multi-line commit message there must be a blank line between the title and the body.

I was unsure on updating the error output or not. If it is updated I guess the error out put should guide towards which element failed the title line or the multi line issue. Let me know your thoughts.

fixes #67 