### PR TITLE
Refactor: kebab-case inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,13 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ contains(github.ref, '-pre') }}
         with:
-          repository_url: https://test.pypi.org/legacy/
-          print_hash: true
-          skip_existing: true
+          repository-url: https://test.pypi.org/legacy/
+          print-hash: true
+          skip-existing: true
           verbose: true
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !contains(github.ref, '-pre') }}
         with:
-          print_hash: true
+          print-hash: true


### PR DESCRIPTION
See message(s) from [latest run](https://github.com/compilerla/conventional-pre-commit/actions/runs/6909721794), e.g.

> Input 'repository_url' has been deprecated with message: The inputs have been normalized to use kebab-case. Use `repository-url` instead.