### PR TITLE
fix: Handle comments by stripping

### DIFF
--- a/conventional_pre_commit/format.py
+++ b/conventional_pre_commit/format.py
@@ -54,6 +54,15 @@ def r_autosquash_prefixes():
     return "|".join(AUTOSQUASH_PREFIXES)
 
 
+def r_comment():
+    """Regex str for comment"""
+    return r"^#.*\r?\n?"
+
+
+def strip_comments(input):
+    return re.sub(r_comment(), "", input, flags=re.MULTILINE)
+
+
 def conventional_types(types=[]):
     """Return a list of Conventional Commits types merged with the given types."""
     if set(types) & set(CONVENTIONAL_TYPES) == set():
@@ -68,6 +77,7 @@ def is_conventional(input, types=DEFAULT_TYPES, optional_scope=True):
 
     Optionally provide a list of additional custom types.
     """
+    input = strip_comments(input)
     types = conventional_types(types)
     pattern = f"^({r_types(types)}){r_scope(optional_scope)}{r_delim()}{r_subject()}{r_body()}"
     regex = re.compile(pattern, re.MULTILINE)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -136,6 +136,7 @@ def test_strip_comments__consecutive():
     """
     result = format.strip_comments(input)
     assert result.count("\n") == 1
+    assert result.strip() == "feat(scope): message"
 
 
 def test_strip_comments__spaced():
@@ -146,6 +147,7 @@ def test_strip_comments__spaced():
     """
     result = format.strip_comments(input)
     assert result.count("\n") == 2
+    assert result.strip() == "feat(scope): message"
 
 
 @pytest.mark.parametrize("type", format.DEFAULT_TYPES)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -122,6 +122,32 @@ def test_conventional_types__custom():
     assert set(["custom", *format.CONVENTIONAL_TYPES]) == set(result)
 
 
+def test_r_comment_single():
+    regex = re.compile(format.r_comment())
+    assert regex.match("# Some comment")
+    assert not regex.match("Some comment")
+    assert not regex.match(" # Some comment")
+
+
+def test_strip_comments__consecutive():
+    input = """feat(scope): message
+# Please enter the commit message for your changes.
+# These are comments usually added by editors, f.ex. with export EDITOR=vim
+    """
+    result = format.strip_comments(input)
+    assert result.count("\n") == 1
+
+
+def test_strip_comments__spaced():
+    input = """feat(scope): message
+# Please enter the commit message for your changes.
+
+# These are comments usually added by editors, f.ex. with export EDITOR=vim
+    """
+    result = format.strip_comments(input)
+    assert result.count("\n") == 2
+
+
 @pytest.mark.parametrize("type", format.DEFAULT_TYPES)
 def test_is_conventional__default_type(type):
     input = f"{type}: message"
@@ -196,6 +222,14 @@ def test_is_conventional__bad_body_multiline_paragraphs():
     """
 
     assert not format.is_conventional(input)
+
+
+def test_is_conventional__comment():
+    input = """feat(scope): message
+# Please enter the commit message for your changes.
+# These are comments usually added by editors, f.ex. with export EDITOR=vim
+"""
+    assert format.is_conventional(input)
 
 
 @pytest.mark.parametrize("char", ['"', "'", "`", "#", "&"])


### PR DESCRIPTION
This is an attempt at solving failed validation of commit texts with trailing comment lines which are usually added when writing the commit message in an editor, f.ex:

```shell
EDITOR=vim git commit -a
```
which on some systems gives you a templated commit message similar to this:
```
# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
# On branch nikolaik/editor-comments
# Your branch is up to date with 'origin/nikolaik/editor-comments'.
#
# Changes to be committed:
#   new file:   yolo
```

Reported in #80 