### PR TITLE
feat(format): improve verbose commit message stripping

### DIFF
--- a/conventional_pre_commit/format.py
+++ b/conventional_pre_commit/format.py
@@ -68,11 +68,12 @@ def r_autosquash_prefixes():
 
 
 def r_verbose_commit_ignored():
-    """Regex str for verbose diff"""
+    """Regex str for the ignored part of verbose commit message templates"""
     return r"^# -{24} >8 -{24}\r?\n.*\Z"
 
 
 def strip_verbose_commit_ignored(input):
+    """Strip the ignored part of verbose commit message templates."""
     return re.sub(r_verbose_commit_ignored(), "", input, flags=re.DOTALL | re.MULTILINE)
 
 

--- a/conventional_pre_commit/format.py
+++ b/conventional_pre_commit/format.py
@@ -67,13 +67,13 @@ def r_autosquash_prefixes():
     return "|".join(AUTOSQUASH_PREFIXES)
 
 
-def r_verbose_diff():
+def r_verbose_commit_ignored():
     """Regex str for verbose diff"""
-    return r"(?P<diff>(^# -* >8 -*$\r?\n)(^# .*$\r?\n)+(diff ){1}(.*\r?\n)*)"
+    return r"^# -{24} >8 -{24}\r?\n(?:.*\r?\n)*.*"
 
 
-def strip_verbose_diff(input):
-    return re.sub(r_verbose_diff(), "", input, flags=re.MULTILINE)
+def strip_verbose_commit_ignored(input):
+    return re.sub(r_verbose_commit_ignored(), "", input, flags=re.MULTILINE)
 
 
 def r_comment():
@@ -99,7 +99,7 @@ def is_conventional(input, types=DEFAULT_TYPES, optional_scope=True, scopes: Opt
 
     Optionally provide a list of additional custom types.
     """
-    input = strip_verbose_diff(input)
+    input = strip_verbose_commit_ignored(input)
     input = strip_comments(input)
     types = conventional_types(types)
     pattern = f"^({r_types(types)}){r_scope(optional_scope, scopes=scopes)}{r_delim()}{r_subject()}{r_body()}"

--- a/conventional_pre_commit/format.py
+++ b/conventional_pre_commit/format.py
@@ -69,11 +69,11 @@ def r_autosquash_prefixes():
 
 def r_verbose_commit_ignored():
     """Regex str for verbose diff"""
-    return r"^# -{24} >8 -{24}\r?\n(?:.*\r?\n)*.*"
+    return r"^# -{24} >8 -{24}\r?\n.*\Z"
 
 
 def strip_verbose_commit_ignored(input):
-    return re.sub(r_verbose_commit_ignored(), "", input, flags=re.MULTILINE)
+    return re.sub(r_verbose_commit_ignored(), "", input, flags=re.DOTALL | re.MULTILINE)
 
 
 def r_comment():

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7,5 +7,5 @@ coverage run -m pytest
 # clean out old coverage results
 rm -rf ./tests/coverage
 
-# regenerate coverate report
+# regenerate coverage report
 coverage html --directory ./tests/coverage

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -166,7 +166,7 @@ def test_strip_comments__spaced():
 
 
 def test_r_verbose_commit_ignored__does_not_match_no_verbose():
-    regex = re.compile(format.r_verbose_commit_ignored(), re.MULTILINE)
+    regex = re.compile(format.r_verbose_commit_ignored(), re.DOTALL | re.MULTILINE)
     input = """feat: some commit message
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
@@ -186,7 +186,7 @@ def test_r_verbose_commit_ignored__does_not_match_no_verbose():
 
 
 def test_r_verbose_commit_ignored__matches_single_verbose_ignored():
-    regex = re.compile(format.r_verbose_commit_ignored(), re.MULTILINE)
+    regex = re.compile(format.r_verbose_commit_ignored(), re.DOTALL | re.MULTILINE)
     input = """feat: some commit message
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
@@ -218,7 +218,7 @@ index ea80a93..fe8a527 100644
 
 
 def test_r_verbose_commit_ignored__matches_double_verbose_ignored():
-    regex = re.compile(format.r_verbose_commit_ignored(), re.MULTILINE)
+    regex = re.compile(format.r_verbose_commit_ignored(), re.DOTALL | re.MULTILINE)
     input = """feat: some commit message
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -187,7 +187,8 @@ def test_r_verbose_commit_ignored__does_not_match_no_verbose():
 
 def test_r_verbose_commit_ignored__matches_single_verbose_ignored():
     regex = re.compile(format.r_verbose_commit_ignored(), re.DOTALL | re.MULTILINE)
-    input = """feat: some commit message
+    input = (
+        """feat: some commit message
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
 #
@@ -209,17 +210,21 @@ index ea80a93..fe8a527 100644
 +++ i/README.md
 @@ -20,3 +20,4 @@ Some hunk header
  Context 1
-
+"""
+        + " "  # This is on purpose to preserve the space from overly eager stripping.
+        + """
  Context 2
 +Added line
 """
+    )
 
     assert regex.search(input)
 
 
 def test_r_verbose_commit_ignored__matches_double_verbose_ignored():
     regex = re.compile(format.r_verbose_commit_ignored(), re.DOTALL | re.MULTILINE)
-    input = """feat: some commit message
+    input = (
+        """feat: some commit message
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
 #
@@ -243,7 +248,9 @@ index ea80a93..fe8a527 100644
 +++ i/README.md
 @@ -20,3 +20,4 @@ Some staged hunk header
  Staged Context 1
-
+"""
+        + " "  # This is on purpose to preserve the space from overly eager stripping.
+        + """
  Staged Context 2
 +Staged added line
 # --------------------------------------------------
@@ -258,10 +265,15 @@ index fe8a527..1c00c14 100644
  Context 3
 -Removed line
 +Added line
-
- Context 4
-
 """
+        + " "  # This is on purpose to preserve the space from overly eager stripping.
+        + """
+ Context 4
+"""
+        + " "  # This is on purpose to preserve the space from overly eager stripping.
+        + """
+"""
+    )
 
     assert regex.search(input)
 
@@ -302,7 +314,8 @@ def test_strip_verbose_commit_ignored__does_not_strip_no_verbose():
 
 
 def test_strip_verbose_commit_ignored__strips_single_verbose_ignored():
-    input = """feat: some commit message
+    input = (
+        """feat: some commit message
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
 #
@@ -324,10 +337,13 @@ index ea80a93..fe8a527 100644
 +++ i/README.md
 @@ -20,3 +20,4 @@ Some hunk header
  Context 1
-
+"""
+        + " "  # This is on purpose to preserve the space from overly eager stripping.
+        + """
  Context 2
 +Added line
 """
+    )
 
     expected = """feat: some commit message
 # Please enter the commit message for your changes. Lines starting
@@ -349,7 +365,8 @@ index ea80a93..fe8a527 100644
 
 
 def test_strip_verbose_commit_ignored__strips_double_verbose_ignored():
-    input = """feat: some commit message
+    input = (
+        """feat: some commit message
 # Please enter the commit message for your changes. Lines starting
 # with '#' will be ignored, and an empty message aborts the commit.
 #
@@ -373,7 +390,9 @@ index ea80a93..fe8a527 100644
 +++ i/README.md
 @@ -20,3 +20,4 @@ Some staged hunk header
  Staged Context 1
-
+"""
+        + " "  # This is on purpose to preserve the space from overly eager stripping.
+        + """
  Staged Context 2
 +Staged added line
 # --------------------------------------------------
@@ -388,10 +407,15 @@ index fe8a527..1c00c14 100644
  Context 3
 -Removed line
 +Added line
-
- Context 4
-
 """
+        + " "  # This is on purpose to preserve the space from overly eager stripping.
+        + """
+ Context 4
+"""
+        + " "  # This is on purpose to preserve the space from overly eager stripping.
+        + """
+"""
+    )
 
     expected = """feat: some commit message
 # Please enter the commit message for your changes. Lines starting

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -209,7 +209,7 @@ index ea80a93..fe8a527 100644
 +++ i/README.md
 @@ -20,3 +20,4 @@ Some hunk header
  Context 1
- 
+
  Context 2
 +Added line
 """
@@ -243,7 +243,7 @@ index ea80a93..fe8a527 100644
 +++ i/README.md
 @@ -20,3 +20,4 @@ Some staged hunk header
  Staged Context 1
- 
+
  Staged Context 2
 +Staged added line
 # --------------------------------------------------
@@ -258,9 +258,9 @@ index fe8a527..1c00c14 100644
  Context 3
 -Removed line
 +Added line
- 
+
  Context 4
- 
+
 """
 
     assert regex.search(input)
@@ -324,7 +324,7 @@ index ea80a93..fe8a527 100644
 +++ i/README.md
 @@ -20,3 +20,4 @@ Some hunk header
  Context 1
- 
+
  Context 2
 +Added line
 """
@@ -373,7 +373,7 @@ index ea80a93..fe8a527 100644
 +++ i/README.md
 @@ -20,3 +20,4 @@ Some staged hunk header
  Staged Context 1
- 
+
  Staged Context 2
 +Staged added line
 # --------------------------------------------------
@@ -388,9 +388,9 @@ index fe8a527..1c00c14 100644
  Context 3
 -Removed line
 +Added line
- 
+
  Context 4
- 
+
 """
 
     expected = """feat: some commit message

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -165,71 +165,251 @@ def test_strip_comments__spaced():
     assert result.strip() == "feat(scope): message"
 
 
-def test_r_verbose_diff__has_diff():
-    regex = re.compile(format.r_verbose_diff(), re.MULTILINE)
-    input = """# ----------- >8 -----------
-# Some comment
-# Some comment
-diff --git a/file b/file
+def test_r_verbose_commit_ignored__does_not_match_no_verbose():
+    regex = re.compile(format.r_verbose_commit_ignored(), re.MULTILINE)
+    input = """feat: some commit message
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch main
+# Your branch is up to date with 'origin/main'.
+#
+# Changes to be committed:
+#	modified:   README.md
+#
+# Changes not staged for commit:
+#	modified:   README.md
+#
 """
 
-    assert regex.match(input)
+    assert not regex.search(input)
 
 
-def test_r_verbose_diff__no_diff():
-    regex = re.compile(format.r_verbose_diff(), re.MULTILINE)
-    input = """# ----------- >8 -----------
-# Some comment
-# Some comment
+def test_r_verbose_commit_ignored__matches_single_verbose_ignored():
+    regex = re.compile(format.r_verbose_commit_ignored(), re.MULTILINE)
+    input = """feat: some commit message
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch main
+# Your branch is up to date with 'origin/main'.
+#
+# Changes to be committed:
+#	modified:   README.md
+#
+# Changes not staged for commit:
+#	modified:   README.md
+#
+# ------------------------ >8 ------------------------
+# Do not modify or remove the line above.
+# Everything below it will be ignored.
+diff --git c/README.md i/README.md
+index ea80a93..fe8a527 100644
+--- c/README.md
++++ i/README.md
+@@ -20,3 +20,4 @@ Some hunk header
+ Context 1
+ 
+ Context 2
++Added line
 """
 
-    assert not regex.match(input)
+    assert regex.search(input)
 
 
-def test_r_verbose_diff__no_extra_comments():
-    regex = re.compile(format.r_verbose_diff(), re.MULTILINE)
-    input = """# ----------- >8 -----------
-diff --git a/file b/file
+def test_r_verbose_commit_ignored__matches_double_verbose_ignored():
+    regex = re.compile(format.r_verbose_commit_ignored(), re.MULTILINE)
+    input = """feat: some commit message
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch main
+# Your branch is up to date with 'origin/main'.
+#
+# Changes to be committed:
+#	modified:   README.md
+#
+# Changes not staged for commit:
+#	modified:   README.md
+#
+# ------------------------ >8 ------------------------
+# Do not modify or remove the line above.
+# Everything below it will be ignored.
+#
+# Changes to be committed:
+diff --git c/README.md i/README.md
+index ea80a93..fe8a527 100644
+--- c/README.md
++++ i/README.md
+@@ -20,3 +20,4 @@ Some staged hunk header
+ Staged Context 1
+ 
+ Staged Context 2
++Staged added line
+# --------------------------------------------------
+# Changes not staged for commit:
+diff --git i/README.md w/README.md
+index fe8a527..1c00c14 100644
+--- i/README.md
++++ w/README.md
+@@ -10,6 +10,7 @@ Some unstaged hunk header
+ Context 1
+ Context 2
+ Context 3
+-Removed line
++Added line
+ 
+ Context 4
+ 
 """
 
-    assert not regex.match(input)
+    assert regex.search(input)
 
 
-def test_strip_verbose_diff__has_diff():
-    input = """feat(scope): message
-# Please enter the commit message for your changes.
-
-# These are comments usually added by editors, f.ex. with export EDITOR=vim
-# ----------- >8 -----------
-# Some comment
-# Some comment
-diff --git a/file b/file
+def test_strip_verbose_commit_ignored__does_not_strip_no_verbose():
+    input = """feat: some commit message
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch main
+# Your branch is up to date with 'origin/main'.
+#
+# Changes to be committed:
+#	modified:   README.md
+#
+# Changes not staged for commit:
+#	modified:   README.md
+#
 """
 
-    result = format.strip_verbose_diff(input)
-    assert result.count("\n") == 4
-    assert (
-        result
-        == """feat(scope): message
-# Please enter the commit message for your changes.
-
-# These are comments usually added by editors, f.ex. with export EDITOR=vim
-"""
-    )
-
-
-def test_strip_verbose_diff__no_diff():
-    input = """feat(scope): message
-# Please enter the commit message for your changes.
-
-# These are comments usually added by editors, f.ex. with export EDITOR=vim
-# ----------- >8 -----------
-# Some comment
-# Some comment
+    expected = """feat: some commit message
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch main
+# Your branch is up to date with 'origin/main'.
+#
+# Changes to be committed:
+#	modified:   README.md
+#
+# Changes not staged for commit:
+#	modified:   README.md
+#
 """
 
-    result = format.strip_verbose_diff(input)
-    assert result == input
+    result = format.strip_verbose_commit_ignored(input)
+    assert result == expected
+
+
+def test_strip_verbose_commit_ignored__strips_single_verbose_ignored():
+    input = """feat: some commit message
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch main
+# Your branch is up to date with 'origin/main'.
+#
+# Changes to be committed:
+#	modified:   README.md
+#
+# Changes not staged for commit:
+#	modified:   README.md
+#
+# ------------------------ >8 ------------------------
+# Do not modify or remove the line above.
+# Everything below it will be ignored.
+diff --git c/README.md i/README.md
+index ea80a93..fe8a527 100644
+--- c/README.md
++++ i/README.md
+@@ -20,3 +20,4 @@ Some hunk header
+ Context 1
+ 
+ Context 2
++Added line
+"""
+
+    expected = """feat: some commit message
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch main
+# Your branch is up to date with 'origin/main'.
+#
+# Changes to be committed:
+#	modified:   README.md
+#
+# Changes not staged for commit:
+#	modified:   README.md
+#
+"""
+
+    result = format.strip_verbose_commit_ignored(input)
+    assert result == expected
+
+
+def test_strip_verbose_commit_ignored__strips_double_verbose_ignored():
+    input = """feat: some commit message
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch main
+# Your branch is up to date with 'origin/main'.
+#
+# Changes to be committed:
+#	modified:   README.md
+#
+# Changes not staged for commit:
+#	modified:   README.md
+#
+# ------------------------ >8 ------------------------
+# Do not modify or remove the line above.
+# Everything below it will be ignored.
+#
+# Changes to be committed:
+diff --git c/README.md i/README.md
+index ea80a93..fe8a527 100644
+--- c/README.md
++++ i/README.md
+@@ -20,3 +20,4 @@ Some staged hunk header
+ Staged Context 1
+ 
+ Staged Context 2
++Staged added line
+# --------------------------------------------------
+# Changes not staged for commit:
+diff --git i/README.md w/README.md
+index fe8a527..1c00c14 100644
+--- i/README.md
++++ w/README.md
+@@ -10,6 +10,7 @@ Some unstaged hunk header
+ Context 1
+ Context 2
+ Context 3
+-Removed line
++Added line
+ 
+ Context 4
+ 
+"""
+
+    expected = """feat: some commit message
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch main
+# Your branch is up to date with 'origin/main'.
+#
+# Changes to be committed:
+#	modified:   README.md
+#
+# Changes not staged for commit:
+#	modified:   README.md
+#
+"""
+
+    result = format.strip_verbose_commit_ignored(input)
+    assert result == expected
 
 
 @pytest.mark.parametrize("type", format.DEFAULT_TYPES)


### PR DESCRIPTION
This improves the regex for the marker in verbose commit messages, that marks the rest of the file as ignored. It simplifies the regex and adds more real test examples.