### PR TITLE
Fix optional scope not respected when using --scopes flag

### DIFF
--- a/conventional_pre_commit/format.py
+++ b/conventional_pre_commit/format.py
@@ -39,7 +39,10 @@ def r_scope(optional=True, scopes: Optional[List[str]] = None):
 
     if scopes:
         scopes_pattern = _get_scope_pattern(scopes)
-        return scopes_pattern
+        if optional:
+            return f"(?:{scopes_pattern})?"
+        else:
+            return scopes_pattern
 
     if optional:
         return r"(\([\w \/:,-]+\))?"

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -66,7 +66,7 @@ def test_r_scope__special_chars():
 
 def test_r_scope__scopes():
     scopes_input = ["api", "client"]
-    result = format.r_scope(scopes=scopes_input)
+    result = format.r_scope(scopes=scopes_input, optional=False)
     regex = re.compile(result)
     assert regex.match("(api)")
     assert regex.match("(client)")

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -152,6 +152,37 @@ def test_subprocess_fail__conventional_with_multiple_scopes(cmd, conventional_co
     assert result == RESULT_FAIL
 
 
+def test_main_success__custom_scopes_optional_scope(conventional_commit_path):
+    result = main(["--scopes", "api,client", conventional_commit_path])
+    assert result == RESULT_SUCCESS
+
+
+def test_main_success__custom_scopes_with_allowed_scope(conventional_commit_with_multiple_scopes_path):
+    result = main(["--scopes", "chore,api,client", conventional_commit_with_multiple_scopes_path])
+    assert result == RESULT_SUCCESS
+
+
+def test_main_fail__custom_scopes_with_disallowed_scope(conventional_commit_with_scope_path):
+    result = main(["--scopes", "api,client", conventional_commit_with_scope_path])
+    assert result == RESULT_FAIL
+
+
+def test_main_fail__custom_scopes_require_scope_no_scope(conventional_commit_path):
+    result = main(["--scopes", "chore,feat,fix,custom", "--force-scope", conventional_commit_path])
+    assert result == RESULT_FAIL
+
+
+def test_main_success__custom_scopes_require_scope_with_allowed_scope(conventional_commit_with_scope_path):
+    result = main(["--scopes", "api,client,scope", "--force-scope", conventional_commit_with_scope_path])
+    assert result == RESULT_SUCCESS
+
+
+def test_main_fail__custom_scopes_require_scope_with_disallowed_scope(conventional_commit_with_scope_path):
+    result = main(
+        ["--scopes", "api,client", "--force-scope", conventional_commit_with_scope_path])
+    assert result == RESULT_FAIL
+
+
 def test_subprocess_success__fixup_commit(cmd, fixup_commit_path):
     result = subprocess.call((cmd, fixup_commit_path))
 

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -178,8 +178,7 @@ def test_main_success__custom_scopes_require_scope_with_allowed_scope(convention
 
 
 def test_main_fail__custom_scopes_require_scope_with_disallowed_scope(conventional_commit_with_scope_path):
-    result = main(
-        ["--scopes", "api,client", "--force-scope", conventional_commit_with_scope_path])
+    result = main(["--scopes", "api,client", "--force-scope", conventional_commit_with_scope_path])
     assert result == RESULT_FAIL
 
 


### PR DESCRIPTION
Fixes issue #111 where the optional flag in the r_scope function was ignored when custom scopes were provided, making the scope mandatory even when optional=True.