### PR TITLE
feat: Give a hint on how to reedit the commit message

### DIFF
--- a/conventional_pre_commit/hook.py
+++ b/conventional_pre_commit/hook.py
@@ -75,6 +75,10 @@ See {Colors.LBLUE}https://git-scm.com/docs/git-commit/#_discussion{Colors.RESTOR
         {Colors.YELLOW}Your commit message does not follow Conventional Commits formatting
         {Colors.LBLUE}https://www.conventionalcommits.org/{Colors.YELLOW}
 
+        Run
+            git commit --edit --file=.git/COMMIT_EDITMSG
+        to reedit the commit message do the commit.
+
         Conventional Commits start with one of the below types, followed by a colon,
         followed by the commit subject and an optional body seperated by a blank line:{Colors.RESTORE}
 


### PR DESCRIPTION
I think it is not common knowledge that the commit message is stored in `.git/COMMIT_EDITMSG` if the hook fails.
Let's give the user a hint and a copy-pastable command to retry the commit.