### PR TITLE
Feat: improve output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,4 @@ repos:
         entry: conventional-pre-commit
         language: python
         stages: [commit-msg]
+        args: [--verbose]

--- a/README.md
+++ b/README.md
@@ -46,33 +46,43 @@ Conventional Commit......................................................Failed
 - duration: 0.07s
 - exit code: 1
 
-[Bad Commit message] >> add a new feature
+[Bad commit message] >> add a new feature
+Your commit message does not follow Conventional Commits formatting
+https://www.conventionalcommits.org/
+```
 
+And with the `--verbose` arg:
+
+```console
+$ git commit -m "add a new feature"
+
+[INFO] Initializing environment for ....
+Conventional Commit......................................................Failed
+- hook id: conventional-pre-commit
+- duration: 0.07s
+- exit code: 1
+
+[Bad commit message] >> add a new feature
 Your commit message does not follow Conventional Commits formatting
 https://www.conventionalcommits.org/
 
-Conventional Commits start with one of the below types, followed by a colon,
-followed by the commit message:
+Conventional Commit messages follow a pattern like:
 
-    build chore ci docs feat fix perf refactor revert style test
+    type(scope): subject
 
-Example commit message adding a feature:
+    extended body
 
-    feat: implement new API
+Please correct the following errors:
 
-Example commit message fixing an issue:
+  - Expected value for 'type' but found none.
+  - Expected value for 'delim' but found none.
+  - Expected value for 'subject' but found none.
 
-    fix: remove infinite loop
+Run:
 
-Example commit with scope in parentheses after the type for more context:
+    git commit --edit --file=.git/COMMIT_EDITMSG
 
-    fix(account): remove infinite loop
-
-Example commit with a body:
-
-    fix: remove infinite loop
-
-    Additional information on the issue caused by the infinite loop
+to edit the commit message and retry the commit.
 ```
 
 Make a (conventional) commit :heavy_check_mark::
@@ -129,7 +139,7 @@ print(is_conventional("custom: this is a conventional commit", types=["custom"])
 
 ```shell
 $ conventional-pre-commit -h
-usage: conventional-pre-commit [-h] [--force-scope] [--scopes SCOPES] [--strict] [types ...] input
+usage: conventional-pre-commit [-h] [--no-color] [--force-scope] [--scopes SCOPES] [--strict] [--verbose] [types ...] input
 
 Check a git commit message for Conventional Commits formatting.
 
@@ -139,9 +149,11 @@ positional arguments:
 
 options:
   -h, --help       show this help message and exit
+  --no-color       Disable color in output.
   --force-scope    Force commit to have scope defined.
   --scopes SCOPES  Optional list of scopes to support. Scopes should be separated by commas with no spaces (e.g. api,client)
   --strict         Force commit to strictly follow Conventional Commits formatting. Disallows fixup! style commits.
+  --verbose        Print more verbose error output.
 ```
 
 Supply arguments on the command-line, or via the pre-commit `hooks.args` property:

--- a/conventional_pre_commit/hook.py
+++ b/conventional_pre_commit/hook.py
@@ -13,6 +13,7 @@ def main(argv=[]):
     )
     parser.add_argument("types", type=str, nargs="*", default=format.DEFAULT_TYPES, help="Optional list of types to support")
     parser.add_argument("input", type=str, help="A file containing a git commit message")
+    parser.add_argument("--no-color", action="store_false", default=True, dest="color", help="Disable color in output.")
     parser.add_argument(
         "--force-scope", action="store_false", default=True, dest="optional_scope", help="Force commit to have scope defined."
     )
@@ -47,7 +48,7 @@ def main(argv=[]):
         with open(args.input, encoding="utf-8") as f:
             commit_msg = f.read()
     except UnicodeDecodeError:
-        print(output.unicode_decode_error())
+        print(output.unicode_decode_error(args.color))
         return RESULT_FAIL
     if args.scopes:
         scopes = args.scopes.split(",")
@@ -61,12 +62,16 @@ def main(argv=[]):
     if format.is_conventional(commit_msg, args.types, args.optional_scope, scopes):
         return RESULT_SUCCESS
 
-    print(output.fail(commit_msg))
+    print(output.fail(commit_msg, use_color=args.color))
 
     if not args.verbose:
-        print(output.verbose_arg())
+        print(output.verbose_arg(use_color=args.color))
     else:
-        print(output.fail_verbose(commit_msg, args.types, args.optional_scope, scopes))
+        print(
+            output.fail_verbose(
+                commit_msg, types=args.types, optional_scope=args.optional_scope, scopes=scopes, use_color=args.color
+            )
+        )
 
     return RESULT_FAIL
 

--- a/conventional_pre_commit/hook.py
+++ b/conventional_pre_commit/hook.py
@@ -27,6 +27,13 @@ def main(argv=[]):
         action="store_true",
         help="Force commit to strictly follow Conventional Commits formatting. Disallows fixup! style commits.",
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        dest="verbose",
+        default=False,
+        help="Print more verbose error output.",
+    )
 
     if len(argv) < 1:
         argv = sys.argv[1:]
@@ -53,8 +60,13 @@ def main(argv=[]):
 
     if format.is_conventional(commit_msg, args.types, args.optional_scope, scopes):
         return RESULT_SUCCESS
+
+    print(output.fail(commit_msg))
+
+    if not args.verbose:
+        print(output.verbose_arg())
     else:
-        print(output.fail(commit_msg))
+        print(output.fail_verbose(commit_msg, args.types, args.optional_scope, scopes))
 
     return RESULT_FAIL
 

--- a/conventional_pre_commit/hook.py
+++ b/conventional_pre_commit/hook.py
@@ -75,6 +75,10 @@ See {Colors.LBLUE}https://git-scm.com/docs/git-commit/#_discussion{Colors.RESTOR
         {Colors.YELLOW}Your commit message does not follow Conventional Commits formatting
         {Colors.LBLUE}https://www.conventionalcommits.org/{Colors.YELLOW}
 
+        Run
+            git commit --edit --file=.git/COMMIT_EDITMSG
+        to reedit the commit message do the commit.
+
         Conventional Commits start with one of the below types, followed by a colon,
         followed by the commit subject and an optional body seperated by a blank line:{Colors.RESTORE}
 

--- a/conventional_pre_commit/hook.py
+++ b/conventional_pre_commit/hook.py
@@ -1,17 +1,10 @@
 import argparse
 import sys
 
-from conventional_pre_commit import format
+from conventional_pre_commit import format, output
 
 RESULT_SUCCESS = 0
 RESULT_FAIL = 1
-
-
-class Colors:
-    LBLUE = "\033[00;34m"
-    LRED = "\033[01;31m"
-    RESTORE = "\033[0m"
-    YELLOW = "\033[00;33m"
 
 
 def main(argv=[]):
@@ -45,17 +38,9 @@ def main(argv=[]):
 
     try:
         with open(args.input, encoding="utf-8") as f:
-            message = f.read()
+            commit_msg = f.read()
     except UnicodeDecodeError:
-        print(
-            f"""
-{Colors.LRED}[Bad Commit message encoding] {Colors.RESTORE}
-
-{Colors.YELLOW}conventional-pre-commit couldn't decode your commit message.{Colors.RESTORE}
-{Colors.YELLOW}UTF-8{Colors.RESTORE} encoding is assumed, please configure git to write commit messages in UTF-8.
-See {Colors.LBLUE}https://git-scm.com/docs/git-commit/#_discussion{Colors.RESTORE} for more.
-        """
-        )
+        print(output.unicode_decode_error())
         return RESULT_FAIL
     if args.scopes:
         scopes = args.scopes.split(",")
@@ -63,47 +48,15 @@ See {Colors.LBLUE}https://git-scm.com/docs/git-commit/#_discussion{Colors.RESTOR
         scopes = args.scopes
 
     if not args.strict:
-        if format.has_autosquash_prefix(message):
+        if format.has_autosquash_prefix(commit_msg):
             return RESULT_SUCCESS
 
-    if format.is_conventional(message, args.types, args.optional_scope, scopes):
+    if format.is_conventional(commit_msg, args.types, args.optional_scope, scopes):
         return RESULT_SUCCESS
     else:
-        print(
-            f"""
-        {Colors.LRED}[Bad Commit message] >>{Colors.RESTORE} {message}
-        {Colors.YELLOW}Your commit message does not follow Conventional Commits formatting
-        {Colors.LBLUE}https://www.conventionalcommits.org/{Colors.YELLOW}
+        print(output.fail(commit_msg))
 
-        Run
-            git commit --edit --file=.git/COMMIT_EDITMSG
-        to reedit the commit message do the commit.
-
-        Conventional Commits start with one of the below types, followed by a colon,
-        followed by the commit subject and an optional body seperated by a blank line:{Colors.RESTORE}
-
-            {" ".join(format.conventional_types(args.types))}
-
-        {Colors.YELLOW}Example commit message adding a feature:{Colors.RESTORE}
-
-            feat: implement new API
-
-        {Colors.YELLOW}Example commit message fixing an issue:{Colors.RESTORE}
-
-            fix: remove infinite loop
-
-        {Colors.YELLOW}Example commit with scope in parentheses after the type for more context:{Colors.RESTORE}
-
-            fix(account): remove infinite loop
-
-        {Colors.YELLOW}Example commit with a body:{Colors.RESTORE}
-
-            fix: remove infinite loop
-
-            Additional information on the issue caused by the infinite loop
-            """
-        )
-        return RESULT_FAIL
+    return RESULT_FAIL
 
 
 if __name__ == "__main__":

--- a/conventional_pre_commit/output.py
+++ b/conventional_pre_commit/output.py
@@ -10,31 +10,55 @@ class Colors:
     RESTORE = "\033[0m"
     YELLOW = "\033[00;33m"
 
+    def __init__(self, enabled=True):
+        self.enabled = enabled
 
-def fail(commit_msg):
+    @property
+    def blue(self):
+        return self.LBLUE if self.enabled else ""
+
+    @property
+    def red(self):
+        return self.LRED if self.enabled else ""
+
+    @property
+    def restore(self):
+        return self.RESTORE if self.enabled else ""
+
+    @property
+    def yellow(self):
+        return self.YELLOW if self.enabled else ""
+
+
+def fail(commit_msg, use_color=True):
+    c = Colors(use_color)
     lines = [
-        f"{Colors.LRED}[Bad commit message] >>{Colors.RESTORE} {commit_msg}"
-        f"{Colors.YELLOW}Your commit message does not follow Conventional Commits formatting{Colors.RESTORE}",
-        f"{Colors.LBLUE}https://www.conventionalcommits.org/{Colors.RESTORE}",
+        f"{c.red}[Bad commit message] >>{c.restore} {commit_msg}"
+        f"{c.yellow}Your commit message does not follow Conventional Commits formatting{c.restore}",
+        f"{c.blue}https://www.conventionalcommits.org/{c.restore}",
     ]
     return os.linesep.join(lines)
 
 
-def verbose_arg():
+def verbose_arg(use_color=True):
+    c = Colors(use_color)
     lines = [
         "",
-        f"{Colors.YELLOW}Use the {Colors.RESTORE}--verbose{Colors.YELLOW} arg for more information{Colors.RESTORE}",
+        f"{c.yellow}Use the {c.restore}--verbose{c.yellow} arg for more information{c.restore}",
     ]
     return os.linesep.join(lines)
 
 
-def fail_verbose(commit_msg: str, types=format.DEFAULT_TYPES, optional_scope=True, scopes: Optional[List[str]] = None):
+def fail_verbose(
+    commit_msg: str, types=format.DEFAULT_TYPES, optional_scope=True, scopes: Optional[List[str]] = None, use_color=True
+):
+    c = Colors(use_color)
     match = format.conventional_match(commit_msg, types, optional_scope, scopes)
     lines = [
         "",
-        f"{Colors.YELLOW}Conventional Commit messages follow a pattern like:",
+        f"{c.yellow}Conventional Commit messages follow a pattern like:",
         "",
-        f"{Colors.RESTORE}    type(scope): subject",
+        f"{c.restore}    type(scope): subject",
         "",
         "    extended body",
         "",
@@ -51,35 +75,37 @@ def fail_verbose(commit_msg: str, types=format.DEFAULT_TYPES, optional_scope=Tru
         groups.pop("sep", None)
 
     if groups.keys():
-        lines.append(f"{Colors.YELLOW}Please correct the following errors:{Colors.RESTORE}")
+        lines.append(f"{c.yellow}Please correct the following errors:{c.restore}")
         lines.append("")
         for group in [g for g, v in groups.items() if not v]:
             if group == "scope":
                 if scopes:
-                    lines.append(f"  - Expected value for 'scope' from: {','.join(scopes)}")
+                    scopt_opts = f"{c.yellow},{c.restore}".join(scopes)
+                    lines.append(f"{c.yellow}  - Expected value for {c.restore}scope{c.yellow} from: {c.restore}{scopt_opts}")
                 else:
-                    lines.append("  - Expected value for 'scope' but found none.")
+                    lines.append(f"{c.yellow}  - Expected value for {c.restore}scope{c.yellow} but found none.{c.restore}")
             else:
-                lines.append(f"  - Expected value for '{group}' but found none.")
+                lines.append(f"{c.yellow}  - Expected value for {c.restore}{group}{c.yellow} but found none.{c.restore}")
 
     lines.extend(
         [
             "",
-            f"{Colors.YELLOW}Run:{Colors.RESTORE}",
+            f"{c.yellow}Run:{c.restore}",
             "",
             "    git commit --edit --file=.git/COMMIT_EDITMSG",
             "",
-            f"{Colors.YELLOW}to edit the commit message and retry the commit.{Colors.RESTORE}",
+            f"{c.yellow}to edit the commit message and retry the commit.{c.restore}",
         ]
     )
     return os.linesep.join(lines)
 
 
-def unicode_decode_error():
+def unicode_decode_error(use_color=True):
+    c = Colors(use_color)
     return f"""
-{Colors.LRED}[Bad commit message encoding]{Colors.RESTORE}
+{c.red}[Bad commit message encoding]{c.restore}
 
-{Colors.YELLOW}conventional-pre-commit couldn't decode your commit message.
+{c.yellow}conventional-pre-commit couldn't decode your commit message.
 UTF-8 encoding is assumed, please configure git to write commit messages in UTF-8.
-See {Colors.LBLUE}https://git-scm.com/docs/git-commit/#_discussion{Colors.YELLOW} for more.{Colors.RESTORE}
+See {c.blue}https://git-scm.com/docs/git-commit/#_discussion{c.yellow} for more.{c.restore}
 """

--- a/conventional_pre_commit/output.py
+++ b/conventional_pre_commit/output.py
@@ -1,0 +1,41 @@
+import os
+
+
+class Colors:
+    LBLUE = "\033[00;34m"
+    LRED = "\033[01;31m"
+    RESTORE = "\033[0m"
+    YELLOW = "\033[00;33m"
+
+
+def fail(commit_msg):
+    lines = [
+        f"{Colors.LRED}[Bad commit message] >>{Colors.RESTORE} {commit_msg}"
+        f"{Colors.YELLOW}Your commit message does not follow Conventional Commits formatting{Colors.RESTORE}",
+        f"{Colors.LBLUE}https://www.conventionalcommits.org/{Colors.RESTORE}",
+        "",
+        f"{Colors.YELLOW}Use the {Colors.RESTORE}--verbose{Colors.YELLOW} arg for more information{Colors.RESTORE}",
+    ]
+    return os.linesep.join(lines)
+
+
+def fail_verbose(commit_msg):
+    lines = [
+        "",
+        f"{Colors.YELLOW}Run{Colors.RESTORE}",
+        "",
+        "    git commit --edit --file=.git/COMMIT_EDITMSG",
+        "",
+        f"{Colors.YELLOW}to edit the commit message and retry the commit.{Colors.RESTORE}",
+    ]
+    return os.linesep.join(lines)
+
+
+def unicode_decode_error():
+    return f"""
+{Colors.LRED}[Bad commit message encoding]{Colors.RESTORE}
+
+{Colors.YELLOW}conventional-pre-commit couldn't decode your commit message.
+UTF-8 encoding is assumed, please configure git to write commit messages in UTF-8.
+See {Colors.LBLUE}https://git-scm.com/docs/git-commit/#_discussion{Colors.YELLOW} for more.{Colors.RESTORE}
+"""

--- a/conventional_pre_commit/output.py
+++ b/conventional_pre_commit/output.py
@@ -13,6 +13,12 @@ def fail(commit_msg):
         f"{Colors.LRED}[Bad commit message] >>{Colors.RESTORE} {commit_msg}"
         f"{Colors.YELLOW}Your commit message does not follow Conventional Commits formatting{Colors.RESTORE}",
         f"{Colors.LBLUE}https://www.conventionalcommits.org/{Colors.RESTORE}",
+    ]
+    return os.linesep.join(lines)
+
+
+def verbose_arg():
+    lines = [
         "",
         f"{Colors.YELLOW}Use the {Colors.RESTORE}--verbose{Colors.YELLOW} arg for more information{Colors.RESTORE}",
     ]

--- a/tests/messages/bad_commit
+++ b/tests/messages/bad_commit
@@ -1,1 +1,1 @@
-bad: message
+bad message

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -436,6 +436,34 @@ index fe8a527..1c00c14 100644
     assert result == expected
 
 
+def test_conventional_regex():
+    regex = format.conventional_regex()
+
+    assert isinstance(regex, re.Pattern)
+    assert "type" in regex.groupindex
+    assert "scope" in regex.groupindex
+    assert "delim" in regex.groupindex
+    assert "subject" in regex.groupindex
+    assert "body" in regex.groupindex
+    assert "multi" in regex.groupindex
+    assert "sep" in regex.groupindex
+
+
+def test_conventional_match():
+    match = format.conventional_match(
+        """test(scope): subject line
+
+body copy
+"""
+    )
+    assert match
+    assert match.group("type") == "test"
+    assert match.group("scope") == "(scope)"
+    assert match.group("delim") == ":"
+    assert match.group("subject").strip() == "subject line"
+    assert match.group("body").strip() == "body copy"
+
+
 @pytest.mark.parametrize("type", format.DEFAULT_TYPES)
 def test_is_conventional__default_type(type):
     input = f"{type}: message"

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -4,6 +4,7 @@ import subprocess
 import pytest
 
 from conventional_pre_commit.hook import RESULT_FAIL, RESULT_SUCCESS, main
+from conventional_pre_commit.output import Colors
 
 
 @pytest.fixture
@@ -103,14 +104,28 @@ def test_main_fail__verbose(bad_commit_path, capsys):
     captured = capsys.readouterr()
     output = captured.out
 
+    assert Colors.LBLUE in output
+    assert Colors.LRED in output
+    assert Colors.RESTORE in output
+    assert Colors.YELLOW in output
     assert "Conventional Commit messages follow a pattern like" in output
     assert f"type(scope): subject{os.linesep}{os.linesep}    extended body" in output
-    assert "Expected value for 'type' but found none." in output
-    assert "Expected value for 'delim' but found none." in output
-    assert "Expected value for 'scope' but found none." in output
-    assert "Expected value for 'subject' but found none." in output
     assert "git commit --edit --file=.git/COMMIT_EDITMSG" in output
     assert "edit the commit message and retry the commit" in output
+
+
+def test_main_fail__no_color(bad_commit_path, capsys):
+    result = main(["--verbose", "--no-color", bad_commit_path])
+
+    assert result == RESULT_FAIL
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    assert Colors.LBLUE not in output
+    assert Colors.LRED not in output
+    assert Colors.RESTORE not in output
+    assert Colors.YELLOW not in output
 
 
 def test_subprocess_fail__missing_args(cmd):

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 import pytest
@@ -92,6 +93,24 @@ def test_main_fail__conventional_commit_bad_multi_line(conventional_commit_bad_m
     result = main([conventional_commit_bad_multi_line_path])
 
     assert result == RESULT_FAIL
+
+
+def test_main_fail__verbose(bad_commit_path, capsys):
+    result = main(["--verbose", "--force-scope", bad_commit_path])
+
+    assert result == RESULT_FAIL
+
+    captured = capsys.readouterr()
+    output = captured.out
+
+    assert "Conventional Commit messages follow a pattern like" in output
+    assert f"type(scope): subject{os.linesep}{os.linesep}    extended body" in output
+    assert "Expected value for 'type' but found none." in output
+    assert "Expected value for 'delim' but found none." in output
+    assert "Expected value for 'scope' but found none." in output
+    assert "Expected value for 'subject' but found none." in output
+    assert "git commit --edit --file=.git/COMMIT_EDITMSG" in output
+    assert "edit the commit message and retry the commit" in output
 
 
 def test_subprocess_fail__missing_args(cmd):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,3 +1,4 @@
+import os
 from conventional_pre_commit.output import fail, fail_verbose, unicode_decode_error
 
 
@@ -11,10 +12,46 @@ def test_fail():
 
 
 def test_fail_verbose():
-    output = fail_verbose("commit msg")
+    output = fail_verbose("commit msg", optional_scope=False)
 
+    assert "Conventional Commit messages follow a pattern like" in output
+    assert f"type(scope): subject{os.linesep}{os.linesep}    extended body" in output
+    assert "Expected value for 'type' but found none." in output
+    assert "Expected value for 'delim' but found none." in output
+    assert "Expected value for 'scope' but found none." in output
+    assert "Expected value for 'subject' but found none." in output
     assert "git commit --edit --file=.git/COMMIT_EDITMSG" in output
     assert "edit the commit message and retry the commit" in output
+
+
+def test_fail_verbose__optional_scope():
+    output = fail_verbose("commit msg", optional_scope=True)
+
+    assert "Expected value for 'scope' but found none." not in output
+
+
+def test_fail_verbose__missing_subject():
+    output = fail_verbose("feat(scope):", optional_scope=False)
+
+    assert "Expected value for 'subject' but found none." in output
+    assert "Expected value for 'type' but found none." not in output
+    assert "Expected value for 'scope' but found none." not in output
+
+
+def test_fail_verbose_no_body_sep():
+    output = fail_verbose(
+        """feat(scope): subject
+body without blank line
+""",
+        optional_scope=False,
+    )
+
+    assert "Expected value for 'sep' but found none." in output
+    assert "Expected value for 'multi' but found none." not in output
+
+    assert "Expected value for 'subject' but found none." not in output
+    assert "Expected value for 'type' but found none." not in output
+    assert "Expected value for 'scope' but found none." not in output
 
 
 def test_unicode_decode_error():

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,9 +1,30 @@
 import os
-from conventional_pre_commit.output import fail, fail_verbose, unicode_decode_error
+from conventional_pre_commit.output import Colors, fail, fail_verbose, unicode_decode_error
+
+
+def test_colors():
+    colors = Colors()
+
+    assert colors.blue == colors.LBLUE
+    assert colors.red == colors.LRED
+    assert colors.restore == colors.RESTORE
+    assert colors.yellow == colors.YELLOW
+
+    colors = Colors(enabled=False)
+
+    assert colors.blue == ""
+    assert colors.red == ""
+    assert colors.restore == ""
+    assert colors.yellow == ""
 
 
 def test_fail():
     output = fail("commit msg")
+
+    assert Colors.LRED in output
+    assert Colors.YELLOW in output
+    assert Colors.LBLUE in output
+    assert Colors.RESTORE in output
 
     assert "Bad commit message" in output
     assert "commit msg" in output
@@ -11,52 +32,90 @@ def test_fail():
     assert "https://www.conventionalcommits.org/" in output
 
 
+def test_fail__no_color():
+    output = fail("commit msg", use_color=False)
+
+    assert Colors.LRED not in output
+    assert Colors.YELLOW not in output
+    assert Colors.LBLUE not in output
+    assert Colors.RESTORE not in output
+
+
 def test_fail_verbose():
     output = fail_verbose("commit msg", optional_scope=False)
 
+    assert Colors.YELLOW in output
+    assert Colors.RESTORE in output
+
+    output = output.replace(Colors.YELLOW, Colors.RESTORE).replace(Colors.RESTORE, "")
+
     assert "Conventional Commit messages follow a pattern like" in output
     assert f"type(scope): subject{os.linesep}{os.linesep}    extended body" in output
-    assert "Expected value for 'type' but found none." in output
-    assert "Expected value for 'delim' but found none." in output
-    assert "Expected value for 'scope' but found none." in output
-    assert "Expected value for 'subject' but found none." in output
+    assert "Expected value for type but found none." in output
+    assert "Expected value for delim but found none." in output
+    assert "Expected value for scope but found none." in output
+    assert "Expected value for subject but found none." in output
     assert "git commit --edit --file=.git/COMMIT_EDITMSG" in output
     assert "edit the commit message and retry the commit" in output
 
 
-def test_fail_verbose__optional_scope():
-    output = fail_verbose("commit msg", optional_scope=True)
+def test_fail_verbose__no_color():
+    output = fail_verbose("commit msg", use_color=False)
 
-    assert "Expected value for 'scope' but found none." not in output
+    assert Colors.LRED not in output
+    assert Colors.YELLOW not in output
+    assert Colors.LBLUE not in output
+    assert Colors.RESTORE not in output
+
+
+def test_fail_verbose__optional_scope():
+    output = fail_verbose("commit msg", optional_scope=True, use_color=False)
+
+    assert "Expected value for scope but found none." not in output
 
 
 def test_fail_verbose__missing_subject():
-    output = fail_verbose("feat(scope):", optional_scope=False)
+    output = fail_verbose("feat(scope):", optional_scope=False, use_color=False)
 
-    assert "Expected value for 'subject' but found none." in output
-    assert "Expected value for 'type' but found none." not in output
-    assert "Expected value for 'scope' but found none." not in output
+    assert "Expected value for subject but found none." in output
+    assert "Expected value for type but found none." not in output
+    assert "Expected value for scope but found none." not in output
 
 
-def test_fail_verbose_no_body_sep():
+def test_fail_verbose__no_body_sep():
     output = fail_verbose(
         """feat(scope): subject
 body without blank line
 """,
         optional_scope=False,
+        use_color=False,
     )
 
-    assert "Expected value for 'sep' but found none." in output
-    assert "Expected value for 'multi' but found none." not in output
+    assert "Expected value for sep but found none." in output
+    assert "Expected value for multi but found none." not in output
 
-    assert "Expected value for 'subject' but found none." not in output
-    assert "Expected value for 'type' but found none." not in output
-    assert "Expected value for 'scope' but found none." not in output
+    assert "Expected value for subject but found none." not in output
+    assert "Expected value for type but found none." not in output
+    assert "Expected value for scope but found none." not in output
 
 
 def test_unicode_decode_error():
     output = unicode_decode_error()
 
+    assert Colors.LRED in output
+    assert Colors.YELLOW in output
+    assert Colors.LBLUE in output
+    assert Colors.RESTORE in output
+
     assert "Bad commit message encoding" in output
     assert "UTF-8 encoding is assumed" in output
     assert "https://git-scm.com/docs/git-commit/#_discussion" in output
+
+
+def test_unicode_decode_error__no_color():
+    output = unicode_decode_error(use_color=False)
+
+    assert Colors.LRED not in output
+    assert Colors.YELLOW not in output
+    assert Colors.LBLUE not in output
+    assert Colors.RESTORE not in output

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,25 @@
+from conventional_pre_commit.output import fail, fail_verbose, unicode_decode_error
+
+
+def test_fail():
+    output = fail("commit msg")
+
+    assert "Bad commit message" in output
+    assert "commit msg" in output
+    assert "Conventional Commits formatting" in output
+    assert "https://www.conventionalcommits.org/" in output
+
+
+def test_fail_verbose():
+    output = fail_verbose("commit msg")
+
+    assert "git commit --edit --file=.git/COMMIT_EDITMSG" in output
+    assert "edit the commit message and retry the commit" in output
+
+
+def test_unicode_decode_error():
+    output = unicode_decode_error()
+
+    assert "Bad commit message encoding" in output
+    assert "UTF-8 encoding is assumed" in output
+    assert "https://git-scm.com/docs/git-commit/#_discussion" in output


### PR DESCRIPTION
Closes #81
Closes #109 

* Color in the output is now optional (on by default) with the `--no-color` arg
* Default error message is much simpler / shorter
* Use the `--verbose` arg to print more information:
  * Example of expected format
  * Specific error messages for mismatches
  * Command to redo the commit after editing the message (cc #116) 