### PR TITLE
feat: show allowed types

### DIFF
--- a/conventional_pre_commit/output.py
+++ b/conventional_pre_commit/output.py
@@ -87,12 +87,7 @@ def fail_verbose(
             else:
                 lines.append(f"{c.yellow}  - Expected value for {c.restore}{group}{c.yellow} but found none.{c.restore}")
 
-    lines.extend(
-        [
-            "",
-            f"Allowed types: {c.blue}{", ".join(types)}{c.restore}"
-        ]
-    )
+    lines.extend(["", f"Allowed types: {c.blue}{", ".join(types)}{c.restore}"])
 
     lines.extend(
         [

--- a/conventional_pre_commit/output.py
+++ b/conventional_pre_commit/output.py
@@ -90,6 +90,13 @@ def fail_verbose(
     lines.extend(
         [
             "",
+            f"Allowed types: {c.blue}{", ".join(types)}{c.restore}"
+        ]
+    )
+
+    lines.extend(
+        [
+            "",
             f"{c.yellow}Run:{c.restore}",
             "",
             "    git commit --edit --file=.git/COMMIT_EDITMSG",


### PR DESCRIPTION
List allowed types in verbose error output.

Since commit types are configureable it might be useful to list them in the verbose error messages