### PR TITLE
fix: skip merge commits patterns

### DIFF
--- a/conventional_pre_commit/format.py
+++ b/conventional_pre_commit/format.py
@@ -70,11 +70,16 @@ class Commit:
 
     def is_merge(self, commit_msg: str = ""):
         """
-        Returns True if input starts with "Merge branch"
-        See the documentation, please https://git-scm.com/docs/git-merge.
+        Returns True if the commit message indicates a merge commit.
+        Matches messages that start with "Merge", including:
+        - Merge branch ...
+        - Merge pull request ...
+        - Merge remote-tracking branch ...
+        - Merge tag ...
+        See https://git-scm.com/docs/git-merge.
         """
         commit_msg = self.clean(commit_msg)
-        return commit_msg.lower().startswith("merge branch ")
+        return bool(re.match(r"^merge\b", commit_msg.lower()))
 
 
 class ConventionalCommit(Commit):

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -397,8 +397,16 @@ def test_has_autosquash_prefix(commit, input, expected_result):
     [
         ("Merge branch '2.x.x' into '1.x.x'", True),
         ("merge branch 'dev' into 'main'", True),
+        ("Merge remote-tracking branch 'origin/master'", True),
+        ("Merge pull request #123 from user/feature-branch", True),
+        ("Merge tag 'v1.2.3' into main", True),
+        ("Merge origin/master into develop", True),
+        ("Merge refs/heads/main into develop", True),
         ("nope not a merge commit", False),
         ("type: subject", False),
+        ("fix: merge bug in auth logic", False),
+        ("chore: merged upstream changes", False),
+        ("MergeSort implemented and tested", False),
     ],
 )
 def test_is_merge_commit(input, expected_result):


### PR DESCRIPTION
Closes #132 
Closes #133 

**Description**:
Improved the is_merge method to detect a broader range of standard Git merge commit formats. Instead of checking only for merge branch, it now supports:

- Merge branch ...
- Merge pull request ...
- Merge remote-tracking branch ...
- Merge tag ...
- Merge ... into ...

Relevant test cases have been added to ensure robustness.

**Motivation**:
This avoids false positives from the Conventional Commit hook when developers use standard merge commits in workflows (e.g. merging main into feature branches).