### PR TITLE
fix: make types and scopes case-insensitive

### DIFF
--- a/conventional_pre_commit/format.py
+++ b/conventional_pre_commit/format.py
@@ -121,7 +121,7 @@ class ConventionalCommit(Commit):
     @property
     def r_types(self):
         """Regex str for valid types."""
-        return self._r_or(self.types)
+        return f"(?i:{self._r_or(self.types)})"
 
     @property
     def r_scope(self):
@@ -130,7 +130,7 @@ class ConventionalCommit(Commit):
             scopes = self._r_or(self.scopes)
             escaped_delimiters = list(map(re.escape, [":", ",", "-", "/"]))  # type: ignore
             delimiters_pattern = self._r_or(escaped_delimiters)
-            scope_pattern = rf"\(\s*(?:{scopes})(?:\s*(?:{delimiters_pattern})\s*(?:{scopes}))*\s*\)"
+            scope_pattern = rf"\(\s*(?:(?i:{scopes}))(?:\s*(?:{delimiters_pattern})\s*(?:(?i:{scopes})))*\s*\)"
 
             if self.scope_optional:
                 return f"(?:{scope_pattern})?"

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -565,9 +565,23 @@ def test_is_valid__default_type(conventional_commit, type):
     assert conventional_commit.is_valid(input)
 
 
+@pytest.mark.parametrize("type", ConventionalCommit.DEFAULT_TYPES)
+def test_is_valid__default_type_uppercase(conventional_commit, type):
+    input = f"{type.upper()}: message"
+
+    assert conventional_commit.is_valid(input)
+
+
 @pytest.mark.parametrize("type", ConventionalCommit.CONVENTIONAL_TYPES)
 def test_is_valid__conventional_type(conventional_commit, type):
     input = f"{type}: message"
+
+    assert conventional_commit.is_valid(input)
+
+
+@pytest.mark.parametrize("type", ConventionalCommit.CONVENTIONAL_TYPES)
+def test_is_valid__conventional_type_uppercase(conventional_commit, type):
+    input = f"{type.upper()}: message"
 
     assert conventional_commit.is_valid(input)
 
@@ -583,6 +597,14 @@ def test_is_valid__custom_type(type):
 @pytest.mark.parametrize("type", ConventionalCommit.CONVENTIONAL_TYPES)
 def test_is_valid__conventional_custom_type(type):
     input = f"{type}: message"
+    conventional_commits = ConventionalCommit(types=CUSTOM_TYPES)
+
+    assert conventional_commits.is_valid(input)
+
+
+@pytest.mark.parametrize("type", ConventionalCommit.CONVENTIONAL_TYPES)
+def test_is_valid__conventional_custom_type_uppercase(type):
+    input = f"{type.upper()}: message"
     conventional_commits = ConventionalCommit(types=CUSTOM_TYPES)
 
     assert conventional_commits.is_valid(input)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -459,6 +459,20 @@ def test_r_scope__scopes(conventional_commit_scope_required):
     assert not regex.match("(api; client)")
 
 
+def test_r_scope__scopes_uppercase(conventional_commit_scope_required):
+    conventional_commit_scope_required.scopes = ["api", "client"]
+    regex = re.compile(conventional_commit_scope_required.r_scope)
+
+    assert regex.match("(API)")
+    assert regex.match("(CLIENT)")
+    assert regex.match("(API, CLIENT)")
+    assert regex.match("(API: CLIENT)")
+    assert regex.match("(API/CLIENT)")
+    assert regex.match("(API-CLIENT)")
+    assert not regex.match("(TEST)")
+    assert not regex.match("(API; CLIENT)")
+
+
 def test_r_delim(conventional_commit):
     regex = re.compile(conventional_commit.r_delim)
 


### PR DESCRIPTION
Types and scopes are currently treated as case-sensitive.
As mentioned in #130, the conventional commits specification requires implementations not to treat units of information (other than "BREAKING CHANGE") as case-sensitive.
This change adds the regex case-insensitive modifier "i" to types and scopes.
